### PR TITLE
Mostrar imágenes completas en la galería

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -301,9 +301,9 @@ h2 {
 }
 
 .proyectos-recientes img {
-  height: 300px;
   width: 100%;
-  object-fit: cover;
+  height: auto;
+  object-fit: contain;
   border-radius: var(--border-radius);
   transition: var(--transition);
   filter: grayscale(0.3);
@@ -314,7 +314,7 @@ h2 {
   margin: 0;
   overflow: hidden;
   border-radius: var(--border-radius);
-  height: 300px;
+  height: auto;
   background: var(--bg-light);
   box-shadow: 0 10px 30px var(--shadow-light);
   transition: var(--transition);
@@ -755,11 +755,11 @@ footer {
   
   .proyecto {
     margin-bottom: 20px;
-    height: 250px;
+    height: auto;
   }
 
   .proyectos-recientes img {
-    height: 250px;
+    height: auto;
   }
 }
 
@@ -844,10 +844,10 @@ footer {
   }
 
   .proyecto {
-    height: 200px;
+    height: auto;
   }
 
   .proyectos-recientes img {
-    height: 200px;
+    height: auto;
   }
 }


### PR DESCRIPTION
## Summary
- Evita que las fotos de la sección de trabajos se recorten estableciendo `object-fit: contain` y `height: auto` en las imágenes de la galería.
- Ajusta las reglas responsive para mantener las fotos completas en distintos tamaños de pantalla.

## Testing
- `npm test` *(falla: package.json no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_689118a695a08329a41c1ed09cbdcd09