### PR TITLE
Fix navbar title visibility on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,16 +38,16 @@
   </head>
   <body>
     <!-- Barra de navegacion -->
-    <nav id="home" class="navbar navbar-expand-md navbar-light sticky-top">
-      <div class="container">
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-toggler" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbar-toggler">
+      <nav id="home" class="navbar navbar-expand-md navbar-light sticky-top">
+        <div class="container">
           <a class="navbar-brand" href="#home">
-            <h3 class="mb-0">Cesar Tattoo</h3>
+            <h3 class="mb-0">César Tattoo</h3>
           </a>
-          <ul class="navbar-nav ms-auto d-flex justify-content-center align-items-center">
+          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-toggler" aria-controls="navbar-toggler" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+          <div class="collapse navbar-collapse" id="navbar-toggler">
+            <ul class="navbar-nav ms-auto d-flex justify-content-center align-items-center">
             <li class="nav-item">
               <a class="nav-link" href="#sobre-mi">SOBRE MÍ</a>
             </li>

--- a/styles/index.css
+++ b/styles/index.css
@@ -33,7 +33,6 @@ html {
 
 .navbar-collapse {
   align-items: center;
-  justify-content: space-between;  
 }
 
 .navbar-brand {


### PR DESCRIPTION
## Summary
- Show "César Tattoo" brand outside the collapsed menu so it remains visible on mobile
- Simplify navbar collapse styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68914e7b16b883298afc7ff7fd8e9b9a